### PR TITLE
Update jgrapht.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.1.1</version>
+		<version>25.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -140,8 +140,8 @@
 
 		<!-- Third party dependencies -->
 		<dependency>
-			<groupId>net.sf.jgrapht</groupId>
-			<artifactId>jgrapht</artifactId>
+			<groupId>org.jgrapht</groupId>
+			<artifactId>jgrapht-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jdom</groupId>


### PR DESCRIPTION
This PR follows the process of updating JGraphT version to 1.3.0.
All projects depending on TrackMate are affected.